### PR TITLE
stop snmp service before create v3 user

### DIFF
--- a/config/setupsnmpv3.sh
+++ b/config/setupsnmpv3.sh
@@ -19,6 +19,9 @@ then
         quit
 fi
 
+# Stop SNMP service
+sudo systemctl stop snmpd
+
 snmpconfig=/etc/snmp/snmpd.conf
 # remove the default config file to prevent the default public community string
 mv $snmpconfig /etc/snmp/snmpd.conf_ORG


### PR DESCRIPTION
if we dont stop the service before creating the user, it will throw an
error and hangs in there